### PR TITLE
use lookup table in alphaIdx()

### DIFF
--- a/ulid.zig
+++ b/ulid.zig
@@ -12,6 +12,15 @@ const text_time_bytes = 10;
 const text_rand_bytes = 16;
 
 fn alphaIdx(c: u8) ?u8 {
+    const alpha_idxs = comptime blk: {
+        var idxs = [1]?u8{null} ** 256;
+        for (0..256) |i| idxs[i] = _alphaIdx(@truncate(i));
+        break :blk idxs;
+    };
+    return alpha_idxs[c];
+}
+
+fn _alphaIdx(c: u8) ?u8 {
     return switch (c) {
         // inline 0...47 => null,
         inline '0'...'9' => |i| i - 48,


### PR DESCRIPTION
i'm not familar with ulid so i'm not sure how valuable this might be, but you could get what appears to be a really nice decode/s speedup by making alphaIdx() use a lookup table and computing it at comptime with the current alphaIdx() method.

i changed the build script to install ulid-bench. here are some results:

```console
$ ../poop/zig-out/bin/poop zig-out/bin/ulid-bench zig-out/bin/ulid-bench-tbl 
Benchmark 1 (45 runs): zig-out/bin/ulid-bench
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           111ms ± 1.58ms     108ms …  116ms          3 ( 7%)        0%
  peak_rss           59.5MB ± 71.3KB    59.3MB … 59.6MB          0 ( 0%)        0%
  cpu_cycles          421M  ± 5.51M      411M  …  437M           5 (11%)        0%
  instructions        801M  ±  340       801M  …  801M           0 ( 0%)        0%
  cache_references   5.10M  ± 13.0K     5.08M  … 5.12M           0 ( 0%)        0%
  cache_misses       59.5K  ± 1.34K     57.1K  … 62.2K           0 ( 0%)        0%
  branch_misses      4.18K  ±  254      3.85K  … 4.65K           0 ( 0%)        0%
Benchmark 2 (68 runs): zig-out/bin/ulid-bench-tbl
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          74.6ms ±  793us    71.8ms … 76.5ms          5 ( 7%)        ⚡- 32.9% ±  0.4%
  peak_rss           59.4MB ± 70.6KB    59.4MB … 59.6MB          0 ( 0%)          -  0.0% ±  0.0%
  cpu_cycles          271M  ± 1.41M      270M  …  279M           3 ( 4%)        ⚡- 35.8% ±  0.3%
  instructions        584M  ± 34.4K      584M  …  584M           3 ( 4%)        ⚡- 27.1% ±  0.0%
  cache_references   5.13M  ±  194K     5.08M  … 6.70M           4 ( 6%)          +  0.5% ±  1.1%
  cache_misses       58.2K  ±  967      56.4K  … 60.6K           0 ( 0%)        ⚡-  2.1% ±  0.7%
  branch_misses      3.98K  ±  243      3.75K  … 4.49K           0 ( 0%)        ⚡-  4.8% ±  2.3%
```

this doesn't seem to affect encoding but the decode/s seems to be around 4x faster. (73516632.0/18490384.0 = 3.98)
```console
travis:/tmp/ulid-zig
$ zig-out/bin/ulid-bench
ids/s=22307627.22
encodes/s=93249622.53
binencodes/s=381733735.38
decodes/s=18490384.03
bindecodes/s=704664526.84
travis:/tmp/ulid-zig
$ zig-out/bin/ulid-bench-tbl 
ids/s=22488232.02
encodes/s=93474603.37
binencodes/s=379483886.73
decodes/s=73516632.84
bindecodes/s=722682249.62
```